### PR TITLE
Custom Widget Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 
 <img src="https://img.shields.io/badge/license-MIT-green"></img>
 
-
 Darwin camera makes it super easy to add camera to your Flutter app. It uses the official camera plugin implementation underneath.
 
 - Captures RAW image at maximum resolution supported by the device camera.
@@ -17,17 +16,11 @@ Darwin camera makes it super easy to add camera to your Flutter app. It uses the
 - Provides a minimal UI for the reviewing the capture before saving image.
 - Supports both Android and iOS.
 
-
-
-| Camera Stream                  | Preview Captured Image         |
-|     :---:       |     :---:       |
+|                                                            Camera Stream                                                            |                                                       Preview Captured Image                                                        |
+| :---------------------------------------------------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------------------------------------------: |
 | <img src="https://user-images.githubusercontent.com/9272830/69421271-a11b1580-0d46-11ea-9dcf-b3d508a2f381.jpeg" width="50%" ></img> | <img src="https://user-images.githubusercontent.com/9272830/69421319-c3149800-0d46-11ea-9664-198faf125a60.jpeg" width="50%" ></img> |
-| Press the `white circular button` to capture image. | Press the `green button` to save the image. |
-| Press the button at the bottom right to `toggle camera`. | Press the close button to `discard` the `captured image`. |
-
-
-
-
+|                                         Press the `white circular button` to capture image.                                         |                                             Press the `green button` to save the image.                                             |
+|                                      Press the button at the bottom right to `toggle camera`.                                       |                                      Press the close button to `discard` the `captured image`.                                      |
 
 ## Getting Started
 
@@ -38,14 +31,15 @@ dependencies:
   ...
   darwin_camera:
     git: https://github.com/atlanhq/darwin-camera
-    
+
 ```
+
 ### iOS
 
 Add two rows to the `ios/Runner/Info.plist`:
 
-* one with the key `Privacy - Camera Usage Description` and a usage description.
-* and one with the key `Privacy - Microphone Usage Description` and a usage description.
+- one with the key `Privacy - Camera Usage Description` and a usage description.
+- and one with the key `Privacy - Microphone Usage Description` and a usage description.
 
 Or in text format add the key:
 
@@ -64,9 +58,8 @@ Change the minimum Android sdk version to 21 (or higher) in your `android/app/bu
 minSdkVersion 21
 ```
 
-
-
 ## Usage example
+
 ```dart
 import 'package:darwin_camera/darwin_camera.dart';
 
@@ -86,45 +79,101 @@ import 'package:darwin_camera/darwin_camera.dart';
 if (result != null && result.isFileAvailable) {
    /// File object returned by Camera.
    print(result.file);
-   /// Path where the file is faced. 
+   /// Path where the file is faced.
    print(result.file.path);
  }
-
 ```
 
-### `DarwinCamera` configuration 
+### `DarwinCamera` customization
+
+You can also pass custom Capture, Toggle, Confirm and Cancel widgets.
+
+```dart
+ DarwinCameraResult result = await Navigator.push(
+   context,
+   MaterialPageRoute(
+     builder: (context) => DarwinCamera(
+       cameraDescription: cameraDescription,
+       filePath: filePath,
+       resolution: ResolutionPreset.high,
+       defaultToFrontFacing: false,
+       quality: 90,
+       captureWidget: Container(
+          height: 50,
+          width: 50,
+          color: Colors.red,
+          child: Center(
+            child: Icon(
+              Icons.camera,
+              color: Colors.white,
+            ),
+          ),
+        ),
+        cameraToggleWidget: Icon(
+          Icons.flip_camera_android,
+          color: Colors.white,
+        ),
+        confirmWidget: Container(
+          height: 50,
+          width: 50,
+          color: Colors.green,
+          child: Center(
+            child: Icon(
+              Icons.check,
+              color: Colors.white,
+            ),
+          ),
+        ),
+        cancelWidget: Container(
+          height: 50,
+          width: 50,
+          color: Colors.black,
+          child: Center(
+            child: Icon(
+              Icons.cancel,
+              color: Colors.white,
+            ),
+          ),
+        ),
+     ),
+   ),
+ );
+```
+
+### `DarwinCamera` configuration
+
 This widget captures an image and save it at the path provided by you.
 
 ```dart
 DarwinCamera({
-  
+
   ///
   /// Flag to enable/disable image compression.
-  bool enableCompression = false, 
-  
+  bool enableCompression = false,
+
   ///
   /// Disables swipe based native back functionality provided by iOS.
   bool disableNativeBackFunctionality = false,
-  
+
   /// @Required
   /// List of cameras availale in the device.
-  /// 
+  ///
   /// How to get the list available cameras?
   /// `List<CameraDescription> cameraDescription = await availableCameras();`
-  List<CameraDescription> cameraDescription, 
-  
+  List<CameraDescription> cameraDescription,
+
   /// @Required
-  
+
   /// Path where the image file will be saved.
-  String filePath, 
-  
-  /// 
+  String filePath,
+
+  ///
   /// Resolution of the image captured
   /// Possible values:
   /// 1. ResolutionPreset.high
   /// 2. ResolutionPreset.medium
   /// 3. ResolutionPreset.low
-  ResolutionPreset resolution = ResolutionPreset.high, 
+  ResolutionPreset resolution = ResolutionPreset.high,
 
   ///
   /// Open front camera instead of back camera on launch.
@@ -136,12 +185,11 @@ DarwinCamera({
   int quality = 90;
 
 })
-
 ```
 
 ## Complete example with permission handling.
-See the [example](https://github.com/atlanhq/darwin-camera/tree/master/example) directory in the github repository
 
+See the [example](https://github.com/atlanhq/darwin-camera/tree/master/example) directory in the github repository
 
 ## Tests
 
@@ -151,8 +199,7 @@ flutter drive --target=test_driver/app.dart
 ```
 
 ## How to contribute?
+
 See [CONTRIBUTING.md](https://github.com/atlanhq/darwin-camera/blob/master/CONTRIBUTING.md)
 
-
 <img src="https://user-images.githubusercontent.com/408863/66741678-a78ab780-ee93-11e9-8d90-b274af222339.png" align="centre" />
-

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -16,13 +16,10 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-
-
   @override
   void initState() {
     super.initState();
   }
-
 
   @override
   Widget build(BuildContext context) {
@@ -65,11 +62,11 @@ class _DarwinCameraTutorialState extends State<DarwinCameraTutorial> {
 
     ///
     /// Microphone permission is required for android devices.
-    /// if permission isn't given before opening camera. 
+    /// if permission isn't given before opening camera.
     /// The app will crash.
-    /// 
+    ///
     /// For iOS devices, it's not neccessary. You can skip microphone permission.
-    /// Required for android devices. 
+    /// Required for android devices.
     await checkForPermissionBasedOnPermissionGroup(
       permissionHandler,
       PermissionGroup.microphone,
@@ -94,6 +91,25 @@ class _DarwinCameraTutorialState extends State<DarwinCameraTutorial> {
           resolution: ResolutionPreset.high,
           defaultToFrontFacing: false,
           quality: 90,
+          cancelWidget: Container(
+            height: 50,
+            width: 50,
+            color: Colors.blue,
+          ),
+          captureWidget: Container(
+            height: 50,
+            width: 50,
+            color: Colors.red,
+          ),
+          cameraToggleWidget: Icon(
+            Icons.flip_camera_android,
+            color: Colors.white,
+          ),
+          confirmWidget: Container(
+            height: 50,
+            width: 50,
+            color: Colors.green,
+          ),
         ),
       ),
     );

--- a/lib/core/ui.dart
+++ b/lib/core/ui.dart
@@ -20,6 +20,7 @@ class RenderCameraStream extends StatelessWidget {
   final Widget leftFooterButton;
   final Widget centerFooterButton;
   final Widget rightFooterButton;
+  final Widget cancelButton;
   final Function onBackPress;
 
   const RenderCameraStream({
@@ -36,6 +37,7 @@ class RenderCameraStream extends StatelessWidget {
     @required this.leftFooterButton,
     @required this.centerFooterButton,
     @required this.rightFooterButton,
+    this.cancelButton,
   }) : super(key: key);
 
   @override
@@ -49,7 +51,7 @@ class RenderCameraStream extends StatelessWidget {
       child: Stack(
         children: <Widget>[
           getCameraStream(context),
-          getHeader(showHeader),
+          getHeader(showHeader, cancelButton),
           getFooter(showFooter),
         ],
       ),
@@ -68,14 +70,15 @@ class RenderCameraStream extends StatelessWidget {
     return ClipRect(
       child: Container(
         child: Center(
-            child: AspectRatio(
-              aspectRatio: cameraAspectRatio,
-              child: CameraPreview(cameraController),
-              // (cameraMode == CameraMode.BARCODE)
-              //     ? Container()
-              //     : previewCamera(cameraState),
-            ),
+          child: AspectRatio(
+            aspectRatio: cameraAspectRatio,
+            child: CameraPreview(cameraController),
+            // (cameraMode == CameraMode.BARCODE)
+            //     ? Container()
+            //     : previewCamera(cameraState),
           ),
+        ),
+
         ///
         /// FIX: Provide multiple presets and aspects ratio to the users.
         // Transform.scale(
@@ -97,7 +100,7 @@ class RenderCameraStream extends StatelessWidget {
   ///
   /// Header is aligned in the top center
   /// It will show back button onf this page
-  Widget getHeader(bool showHeader) {
+  Widget getHeader(bool showHeader, Widget child) {
     return Visibility(
       child: Align(
         alignment: Alignment.topCenter,
@@ -116,6 +119,7 @@ class RenderCameraStream extends StatelessWidget {
                   key: ValueKey("HeaderCancelButton"),
                   opacity: 1,
                   padding: padding_a_xs,
+                  child: child,
                   onTap: () {
                     if (onBackPress != null) {
                       onBackPress();
@@ -225,6 +229,7 @@ class CancelButton extends StatelessWidget {
   final Function onTap;
   final double opacity;
   final EdgeInsets padding;
+  final Widget child;
 
   ///
   CancelButton({
@@ -232,6 +237,7 @@ class CancelButton extends StatelessWidget {
     @required this.onTap,
     @required this.opacity,
     this.padding = padding_a_s,
+    this.child,
   }) : super(key: key);
 
   @override
@@ -242,15 +248,16 @@ class CancelButton extends StatelessWidget {
           onTap();
         }
       },
-      child: Container(
-        padding: padding,
-        child: Opacity(
-          opacity: opacity,
-          child: Icon(
-            Icons.cancel,
-            color: DarwinWhite,
-            size: grid_spacer * 4,
-          ),
+      child: Opacity(
+        opacity: opacity,
+        child: Container(
+          padding: padding,
+          child: child ??
+              Icon(
+                Icons.cancel,
+                color: DarwinWhite,
+                size: grid_spacer * 4,
+              ),
         ),
       ),
     );
@@ -277,12 +284,14 @@ class CaptureButton extends StatelessWidget {
   final double buttonSize;
   final double buttonPosition;
   final Function onTap;
+  final Widget child;
 
   CaptureButton({
     Key key,
     @required this.buttonSize,
     @required this.buttonPosition,
     @required this.onTap,
+    this.child,
   }) : super(key: key);
 
   @override
@@ -298,34 +307,35 @@ class CaptureButton extends StatelessWidget {
       height: grid_spacer * 14,
       width: grid_spacer * 14,
       alignment: Alignment.center,
-      child: Stack(
-        children: <Widget>[
-          AnimatedContainer(
-            alignment: Alignment.center,
-            duration: Duration(milliseconds: 100),
-            width: buttonSize,
-            height: buttonSize,
-            decoration: BoxDecoration(
-              color: DarwinWhite.withOpacity(0.25),
-              borderRadius: BorderRadius.circular(grid_spacer * 12),
-            ),
-          ),
-          AnimatedPositioned(
-            duration: Duration(milliseconds: 100),
-            top: buttonPosition,
-            left: buttonPosition,
-            child: AnimatedContainer(
-              duration: Duration(milliseconds: 100),
-              width: grid_spacer * 8,
-              height: grid_spacer * 8,
-              decoration: BoxDecoration(
-                color: DarwinWhite,
-                borderRadius: BorderRadius.circular(grid_spacer * 10),
+      child: child ??
+          Stack(
+            children: <Widget>[
+              AnimatedContainer(
+                alignment: Alignment.center,
+                duration: Duration(milliseconds: 100),
+                width: buttonSize,
+                height: buttonSize,
+                decoration: BoxDecoration(
+                  color: DarwinWhite.withOpacity(0.25),
+                  borderRadius: BorderRadius.circular(grid_spacer * 12),
+                ),
               ),
-            ),
+              AnimatedPositioned(
+                duration: Duration(milliseconds: 100),
+                top: buttonPosition,
+                left: buttonPosition,
+                child: AnimatedContainer(
+                  duration: Duration(milliseconds: 100),
+                  width: grid_spacer * 8,
+                  height: grid_spacer * 8,
+                  decoration: BoxDecoration(
+                    color: DarwinWhite,
+                    borderRadius: BorderRadius.circular(grid_spacer * 10),
+                  ),
+                ),
+              ),
+            ],
           ),
-        ],
-      ),
     );
   }
 }
@@ -349,9 +359,12 @@ class CaptureButton extends StatelessWidget {
 
 class ConfirmButton extends StatelessWidget {
   final Function onTap;
+  final Widget child;
+
   const ConfirmButton({
     Key key,
     @required this.onTap,
+    this.child,
   }) : super(key: key);
 
   @override
@@ -361,19 +374,20 @@ class ConfirmButton extends StatelessWidget {
         width: grid_spacer * 14,
         height: grid_spacer * 14,
         alignment: Alignment.center,
-        child: Container(
-          width: grid_spacer * 10,
-          height: grid_spacer * 10,
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(grid_spacer * 12),
-            color: DarwinSuccess,
-          ),
-          child: Icon(
-            Icons.check,
-            color: DarwinWhite,
-            size: grid_spacer * 4,
-          ),
-        ),
+        child: child ??
+            Container(
+              width: grid_spacer * 10,
+              height: grid_spacer * 10,
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(grid_spacer * 12),
+                color: DarwinSuccess,
+              ),
+              child: Icon(
+                Icons.check,
+                color: DarwinWhite,
+                size: grid_spacer * 4,
+              ),
+            ),
       ),
       onTap: () {
         if (onTap != null) {
@@ -407,10 +421,13 @@ class ConfirmButton extends StatelessWidget {
 class ToggleCameraButton extends StatelessWidget {
   final Function onTap;
   final double opacity;
+  final Widget child;
+
   const ToggleCameraButton({
     Key key,
     @required this.onTap,
     this.opacity = 1.0,
+    this.child,
   }) : super(key: key);
 
   @override
@@ -420,11 +437,12 @@ class ToggleCameraButton extends StatelessWidget {
         padding: padding_a_s,
         child: Opacity(
           opacity: opacity,
-          child: Icon(
-            Icons.refresh,
-            color: DarwinWhite,
-            size: grid_spacer * 4,
-          ),
+          child: child ??
+              Icon(
+                Icons.refresh,
+                color: DarwinWhite,
+                size: grid_spacer * 4,
+              ),
         ),
       ),
       onTap: onTap,

--- a/lib/darwin_camera.dart
+++ b/lib/darwin_camera.dart
@@ -44,6 +44,22 @@ class DarwinCamera extends StatefulWidget {
   /// Possible values `0 - 100`
   final int quality;
 
+  ///
+  /// Custom Cancel Widget
+  final Widget cancelWidget;
+
+  ///
+  /// Custom Capture Widget
+  final Widget captureWidget;
+
+  ///
+  /// Custom Camera Toggle Widget
+  final Widget cameraToggleWidget;
+
+  ///
+  /// Custom Confirm button Widget
+  final Widget confirmWidget;
+
   DarwinCamera({
     Key key,
     @required this.cameraDescription,
@@ -53,6 +69,10 @@ class DarwinCamera extends StatefulWidget {
     this.disableNativeBackFunctionality = false,
     this.defaultToFrontFacing = false,
     this.quality = 90,
+    this.cancelWidget,
+    this.captureWidget,
+    this.cameraToggleWidget,
+    this.confirmWidget,
   })  : assert(cameraDescription != null),
         assert(filePath != null),
         assert(quality >= 0 && quality <= 100),
@@ -212,18 +232,22 @@ class _DarwinCameraState extends State<DarwinCamera>
       leftFooterButton: CancelButton(
         onTap: null,
         opacity: 0,
+        // child: widget.cancelWidget,
       ),
       centerFooterButton: CaptureButton(
         key: ValueKey("CaptureButton"),
         buttonPosition: captureButtonPosition,
         buttonSize: captureButtonSize,
         onTap: captureImage,
+        child: widget.captureWidget,
       ),
       rightFooterButton: ToggleCameraButton(
         key: ValueKey("CameraToggleButton"),
         onTap: toggleCamera,
         opacity: showCameraToggle ? 1.0 : 0.0,
+        child: widget.cameraToggleWidget,
       ),
+      cancelButton: widget.cancelWidget,
     );
   }
 
@@ -241,12 +265,14 @@ class _DarwinCameraState extends State<DarwinCamera>
         onTap: () {
           setCameraState(CameraState.NOT_CAPTURING);
         },
+        child: widget.cancelWidget,
       ),
       centerFooterButton: ConfirmButton(
         key: ValueKey("ConfirmImageButton"),
         onTap: () {
           DarwinCameraHelper.returnResult(context, file: file);
         },
+        child: widget.confirmWidget,
       ),
       rightFooterButton: CancelButton(
         onTap: null,


### PR DESCRIPTION
# Description

Added the functionality to use custom widgets in place of Capture, Toggle, Confirm and Cancel buttons.
Also added documentation regarding the same.

| param                  | type   | default value |
|------------------------|--------|---------------|
| `captureWidget` | `Widget` | null         |
| `cameraToggleWidget` | `Widget` | null         |
| `confirmWidget` | `Widget` | null         |
| `cancelWidget` | `Widget` | null         |


Fixes issue:
- Give developers option to use custom buttons.. Fixes [#4](https://github.com/atlanhq/darwin-camera/issues/4)


## Screenshots

![Screenshot_2021-04-09-01-31-20-725_com atlan darwin_camera_example](https://user-images.githubusercontent.com/51574716/114090350-ed7fda80-98d4-11eb-82f7-dd95f11541d7.jpg)
![Screenshot_2021-04-09-01-31-26-152_com atlan darwin_camera_example](https://user-images.githubusercontent.com/51574716/114090354-ef499e00-98d4-11eb-95fd-37da90453ff6.jpg)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

There were no breaking changes, just ran the normal tests given in the project, and it passed.